### PR TITLE
Add metabase typedefs

### DIFF
--- a/amundsenatlastypes/__init__.py
+++ b/amundsenatlastypes/__init__.py
@@ -93,7 +93,15 @@ class Initializer:
     def create_data_owner_relation(self):
         self.create_or_update(self.get_schema_dict(data_owner_schema), "Data Owner Relation")
 
-    def create_required_entities(self, fix_existing_data=False):
+    def install_metabase_types(self):
+        self.create_or_update(self.get_schema_dict(metabase_entities_schema),
+                              "Metabase entity types")
+
+    def create_additional_types(self):
+        self.install_metabase_types()
+
+    def create_required_entities(self, fix_existing_data=False,
+        additional_types=False):
         """
         IMPORTANT: The order of the entity definition matters.
         Please keep this order.
@@ -112,3 +120,5 @@ class Initializer:
         self.create_table_partition_schema()
         self.create_hive_table_partition()
         self.create_data_owner_relation()
+        if additional_types:
+            self.create_additional_types()

--- a/amundsenatlastypes/schema/0000-metabase/0001-metabase-v0.json
+++ b/amundsenatlastypes/schema/0000-metabase/0001-metabase-v0.json
@@ -1,0 +1,310 @@
+{
+  "enumDefs": [],
+  "structDefs": [],
+  "classificationDefs": [],
+  "entityDefs": [
+    {
+      "superTypes": [
+        "DataSet"
+      ],
+      "name": "metabase_entity",
+      "description": "Base metabase entity",
+      "serviceType": "metabase",
+      "attributeDefs": [
+        {
+          "name": "id",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        },
+        {
+          "name": "url",
+          "isOptional": false,
+          "isUnique": false,
+          "isIndexable": true,
+          "typeName": "string"
+        }
+      ]
+    },
+    {
+      "superTypes": [
+        "metabase_entity"
+      ],
+      "name": "metabase_collection",
+      "description": "Metabase collection",
+      "serviceType": "metabase",
+      "attributeDefs": []
+    },
+    {
+      "superTypes": [
+        "Process"
+      ],
+      "name": "metabase_process",
+      "description": "MB process",
+      "serviceType": "metabase",
+      "attributeDefs": [
+        {
+          "name": "lineageType",
+          "isOptional": true,
+          "isUnique": false,
+          "isIndexable": true,
+          "typeName": "string"
+        }
+      ]
+    },
+    {
+      "superTypes": [
+        "metabase_entity"
+      ],
+      "name": "metabase_question",
+      "description": "Question",
+      "serviceType": "metabase",
+      "attributeDefs": [
+        {
+          "name": "result_metadata",
+          "isOptional": true,
+          "isUnique": false,
+          "isIndexable": false,
+          "typeName": "array<map<string,string>>"
+        },
+        {
+          "name": "dataset_query",
+          "isOptional": true,
+          "isUnique": false,
+          "isIndexable": false,
+          "typeName": "map<string,string>"
+        },
+        {
+          "name": "native_query",
+          "isOptional": true,
+          "isUnique": false,
+          "isIndexable": false,
+          "typeName": "string"
+        }
+      ]
+    },
+    {
+      "superTypes": [
+        "metabase_entity"
+      ],
+      "name": "metabase_dashboard",
+      "description": "Dashboard",
+      "serviceType": "metabase",
+      "attributeDefs": []
+    },
+    {
+      "superTypes": [
+        "Referenceable"
+      ],
+      "name": "metabase_user_group",
+      "description": "Metabase user group",
+      "serviceType": "metabase",
+      "attributeDefs": [
+        {
+          "name": "id",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        },
+        {
+          "name": "name",
+          "isOptional": true,
+          "isUnique": false,
+          "isIndexable": true,
+          "typeName": "string"
+        },
+        {
+          "name": "url",
+          "isOptional": false,
+          "isUnique": false,
+          "isIndexable": true,
+          "typeName": "string"
+        }
+      ]
+    }
+  ],
+  "relationshipDefs": [
+    {
+      "name": "metabase_group__collection",
+      "serviceType": "metabase",
+      "typeVersion": "1.0",
+      "relationshipCategory": "AGGREGATION",
+      "relationshipLabel": "__mb_group.read_collections",
+      "endDef1": {
+        "type": "metabase_user_group",
+        "name": "read_collections",
+        "isContainer": true,
+        "cardinality": "SET"
+      },
+      "endDef2": {
+        "type": "metabase_collection",
+        "name": "reader_groups",
+        "isContainer": false,
+        "cardinality": "SET"
+      },
+      "attributeDefs": [
+        {
+          "name": "metabase_user_group_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        },
+        {
+          "name": "metabase_collection_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        }
+      ],
+      "propagateTags": "NONE"
+    },
+    {
+      "name": "metabase_group__users",
+      "serviceType": "metabase",
+      "typeVersion": "1.0",
+      "relationshipCategory": "AGGREGATION",
+      "relationshipLabel": "__mb_group.users",
+      "endDef1": {
+        "type": "metabase_user_group",
+        "name": "users",
+        "isContainer": true,
+        "cardinality": "SET"
+      },
+      "endDef2": {
+        "type": "User",
+        "name": "metabase_groups",
+        "isContainer": false,
+        "cardinality": "SET"
+      },
+      "attributeDefs": [
+        {
+          "name": "metabase_user_group_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        },
+        {
+          "name": "User_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        }
+      ],
+      "propagateTags": "NONE"
+    },
+    {
+      "name": "metabase_collection_children",
+      "serviceType": "metabase",
+      "typeVersion": "1.0",
+      "relationshipCategory": "AGGREGATION",
+      "relationshipLabel": "__mb_collection.items",
+      "endDef1": {
+        "type": "metabase_collection",
+        "name": "items",
+        "isContainer": true,
+        "cardinality": "SET"
+      },
+      "endDef2": {
+        "type": "metabase_entity",
+        "name": "parent_collection",
+        "isContainer": false,
+        "cardinality": "SINGLE"
+      },
+      "attributeDefs": [
+        {
+          "name": "metabase_collection_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        },
+        {
+          "name": "metabase_entity_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        }
+      ],
+      "propagateTags": "NONE"
+    },
+    {
+      "name": "metabase_dashboard__question",
+      "serviceType": "metabase",
+      "typeVersion": "1.0",
+      "relationshipCategory": "AGGREGATION",
+      "relationshipLabel": "__mb_dashboard.questions",
+      "endDef1": {
+        "type": "metabase_dashboard",
+        "name": "questions",
+        "isContainer": true,
+        "cardinality": "SET"
+      },
+      "endDef2": {
+        "type": "metabase_question",
+        "name": "dashboards",
+        "isContainer": false,
+        "cardinality": "SET"
+      },
+      "attributeDefs": [
+        {
+          "name": "metabase_dashboard_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        },
+        {
+          "name": "metabase_question_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        }
+      ],
+      "propagateTags": "ONE_TO_TWO"
+    },
+    {
+      "name": "metabase_question__table",
+      "serviceType": "metabase",
+      "typeVersion": "1.0",
+      "relationshipCategory": "AGGREGATION",
+      "relationshipLabel": "__mb_question.tables",
+      "endDef1": {
+        "type": "metabase_question",
+        "name": "referenced_tables",
+        "isContainer": true,
+        "cardinality": "SET"
+      },
+      "endDef2": {
+        "type": "Table",
+        "name": "used_in_mb_questions",
+        "isContainer": false,
+        "cardinality": "SET"
+      },
+      "attributeDefs": [
+        {
+          "name": "metabase_question_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        },
+        {
+          "name": "Table_qualifiedName",
+          "isOptional": false,
+          "isUnique": true,
+          "isIndexable": true,
+          "typeName": "string"
+        }
+      ],
+      "propagateTags": "NONE"
+    }
+  ]
+}

--- a/amundsenatlastypes/types_def.py
+++ b/amundsenatlastypes/types_def.py
@@ -16,3 +16,4 @@ reader_referenceable_relation = get_schema("schema/04_reader_referenceable_relat
 table_partition_schema = get_schema("schema/05_table_partition_schema.json")
 hive_table_partition = get_schema("schema/05_1_hive_table_partition.json")
 data_owner_schema = get_schema("schema/06_user_table_owner_relation.json")
+metabase_entities_schema = get_schema("schema/0000-metabase/0001-metabase-v0.json")


### PR DESCRIPTION
This will enable 
1. Optional installation of additional types which are not directly involved with amundsen
2. Metabase types for collections, dashboard, questions and groups
3. Also establish required relationship attributes and lineages

We are using the following migrator to install the typedefs.

N.B.

```python3
import json
from glob import glob

from metadata.ingest.utils.common import partition


class AtlasMigrator:

    def __init__(self, atlas_util: 'AtlasUtil') -> None:
        super().__init__()
        self.atlas_util = atlas_util

    def run_migrations(self, base_dir: str, with_cleanup: bool = False):
        json_files = glob(f"{base_dir}/**/*.json", recursive=True)
        json_files.sort()
        for migration in json_files:
            with open(migration, "r") as inp:
                types_def = json.load(inp)

            if with_cleanup:
                self.cleanup_all_type_defs(types_def)

            try:
                self.atlas_util.client.typedefs.update(data=types_def)
            except Exception as e:
                self.atlas_util.new_client.typedef.create_atlas_typedefs(types_def)

    def cleanup_type_def(self, type_def_name: str):
        search = self.atlas_util.new_client.discovery.basic_search(type_def_name, None, None, True, 10000, 0)
        guid_batches = (search.entities and partition([e.guid for e in search.entities], 150)) or []
        for batch in guid_batches:
            self.atlas_util.new_client.entity.delete_entities_by_guids(batch)

        search = self.atlas_util.new_client.discovery.basic_search(type_def_name, None, None, False, 10000, 0)
        guid_batches = (search.entities and partition([e.guid for e in search.entities], 150)) or []
        for batch in guid_batches:
            self.atlas_util.new_client.entity.purge_entities_by_guids(batch)
        # TODO: Delete is buggy, https://www.mail-archive.com/dev@atlas.apache.org/msg23040.html
        # self.atlas_util.new_client.typedef.delete_type_by_name(type_def_name)
        

    def cleanup_all_type_defs(self, types_def):
        # This outer loop ensures dependency cant stop us!
        for i in ([] or range(len(types_def["entityDefs"]))):
            for entity_def in types_def["entityDefs"]:
                try:
                    self.cleanup_type_def(entity_def["name"])
                except Exception as e:
                    pass



```